### PR TITLE
fix: capitalize Zondax in package.json GitHub URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zondax/ledger-flare-js.git"
+    "url": "git+https://github.com/Zondax/ledger-flare-js.git"
   },
   "keywords": [
     "Ledger",
@@ -16,9 +16,9 @@
   "author": "Zondax GmbH",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/zondax/ledger-flare-js/issues"
+    "url": "https://github.com/Zondax/ledger-flare-js/issues"
   },
-  "homepage": "https://github.com/zondax/ledger-flare-js",
+  "homepage": "https://github.com/Zondax/ledger-flare-js",
   "dependencies": {
     "@ledgerhq/hw-app-eth": "^6.45.9",
     "@ledgerhq/hw-transport": "^6.31.7",


### PR DESCRIPTION
Required for OIDC trusted publishing: npm's sigstore provenance verifier
case-sensitively compares package.json's repository.url / bugs.url / homepage
against the GitHub provenance attestation (`Zondax/ledger-flare-js`) and rejects
publish with 422 if they don't match.
